### PR TITLE
Update 0000-element-and-fragment.md

### DIFF
--- a/active/0000-element-and-fragment.md
+++ b/active/0000-element-and-fragment.md
@@ -65,7 +65,7 @@ template to:
 The output changes to
 
 ````html
-<span clas="special magical" data-my-id="1">
+<span class="special magical" data-my-id="1">
   Hello Tomster.
 </span>
 ````


### PR DESCRIPTION
A `class` attribute is missing an `s` in one of the output samples.