### PR TITLE
First-pass edits

### DIFF
--- a/text/0000-glimmer-component.md
+++ b/text/0000-glimmer-component.md
@@ -16,7 +16,7 @@ Community best-practice has evolved overwhelmingly in favor of "data down, actio
 
 ## Template-based control over a component's root element
 
-A glimmer-component's own root element appears within its template. This greatly simplifies the learning experience for all HTML-competent learners who are starting with Ember. It reduces the overall API surface (no more `tagname`, `attributeBindings`, `classNameBindings`, etc).
+A Glimmer component's own root element appears within its template. This greatly simplifies the learning experience for all HTML-competent learners who are starting with Ember. It reduces the overall API surface (no more `tagName`, `attributeBindings`, `classNameBindings`, etc).
 
 ## HTML-like syntax
 
@@ -28,15 +28,13 @@ A Glimmer component may be invoked like `<my-component />` instead of `{{my-comp
 
 ## Portability between traditional Ember apps and micro-apps that depend only on Glimmer
 
-Glimmer components are designed to depend only on features of Glimmer, so they can be used in places where the full power of Ember is not needed and bytesize is at a premium.
-
+Glimmer components are designed to depend only on features of Glimmer, so they can be used in places where the full power of Ember is not needed and byte-size is at a premium.
 
 # Detailed design
 
 The design is divided into the following sections:
 
  - "Glossary" defines key concepts that will be used in the remaining sections of the design.
- 
  - "Template Invocation Syntax" explains how to call a Glimmer component from another template.
  - "Template Definition Syntax" explains what goes inside a component's own template.
  - "Javascript Syntax" addresses concerns like "can my component's class be a plain old ES2015 `class`? What ECMA features can we use to define component's implementation?"
@@ -45,81 +43,90 @@ The design is divided into the following sections:
 
 ## Glossary
 
-attribute: an HTML attribute. Present in the DOM with a name an optional string value.
-
-argument: a value passed into a component by the component's caller. 
-
-fragment: a component that results in zero or more than one top-most DOM Elements. This is analogous to an `Ember.Component` with `tagName: ""`.
-
+* **attribute**: An HTML attribute. Present in the DOM with a name and optional string value.
+* **argument**: A value passed into a component by the component's caller. The
+  "data" in "data down".
+* **fragment**: A component that results in zero or more than one top-most DOM elements. This is analogous to an `Ember.Component` with `tagName: ""`.
 
 ## Template Invocation Syntax
 
-The naming rules for Glimmer components follow the existing rules for component names: they must contain a dash (or be namespaced via `::` as described in the [Module Unification RFC](https://github.com/emberjs/rfcs/blob/6caed4c882e7be94af1d1e9fb0d723db725c691c/text/0143-module-unification.md)). This prevents any component from colliding with a future HTML tag (the dash is reserved for custom elements within the HTML specification).
+The naming rules for Glimmer components follow the existing rules for component names: They must contain a dash or be namespaced via `::` as described in the [Module Unification RFC](https://github.com/emberjs/rfcs/blob/6caed4c882e7be94af1d1e9fb0d723db725c691c/text/0143-module-unification.md). These requirements prevent any component from colliding with a future HTML tag. Dashes are reserved for custom elements within the HTML specification, and `::` is not part of a valid HTML tag name.
 
 Like HTML tags, Glimmer components have both an abbreviated self-closing form and an expanded form:
 
-    <power-select/>
-    <power-select></power-select>
+```hbs
+<power-select/>
+<power-select></power-select>
+```
 
 ### Attributes
 
 Attributes on Glimmer components are true HTML attributes. They will be reflected into the DOM. So:
 
-    <power-select class="important" data-foo={{foo}} />
-    
-expresses the intention to set the `class` and `data-foo` HTML attributes on the top-most HTML Element defined by the `power-select` component. The point of this feature is:
+```hbs
+<power-select class="important" data-foo={{foo}} />
+```
 
- - to avoid the need for every component author to explicitly list every possible HTML attribute they want to expose to callers.
- 
- - to harmonize the behavior between the component invocation case:
- 
-     <power-select class="important">
-     
-     and the plain element case:
-     
-     <div class="important"> 
+expresses the intention to set the `class` and `data-foo` HTML attributes on the top-most HTML element defined by the `power-select` component. The point of this feature is two-fold.
 
-Fragments do not have a topmost element, and therefore do not automatically reflect HTML attributes. It is not an error to pass attributes to a fragment, they just have no default behavior. The component author may still choose to use them. The special syntax `@@attributes` means "pass all the attributes I was given onto this element:
+First, it avoids the need for every component author to explicitly list every possible HTML attribute they want to expose to callers. In Ember components the `attributeBindings` API is used for this end, and in practice developers find that API unwieldy and difficult to master.
 
-    <some-component @@attributes />
-    
-This makes it possible to compose a new component out of an existing component without adding additional DOM and without needing to explicitly pass a fixed list of attributes onward. *Please not that `@@` is not general-purpose attribute splatting. Only `@@attributes` is defined, not `@@myBagOfStuff`. I am being conservative here because I am more confident in our ability to statically optimize the specific, common case than the most general case.*
+Second, it harmonizes the behavior between the component invocation case and
+plain element invocation. For example to set a `class` on a Glimmer component
+the following syntax is used:
 
-In HTML, every attribute value is necessarily either a string or completely absent. In Ember Handlebars templates, we can dynamically bind arbitrary types to attributes. So we must define semantics for what happens to non-string values:
+```hbs
+<power-select class="important">
+```
 
- - boolean values express the addition or removal of the attribute. So given `isReady = true`, then
- 
-        <my-checkbox checked={{isReady}} />
-    
-    will result in the HTML attribute `checked`, not `checked="true"`. When the value is false, the `checked` attribute will be entirely absent.
-     
- - function values result in a property set on the HTML Element. So
- 
-        <some-component onclick={{myFunction}}
-     
-     installs an event handler implemented equivalent to `element.onclick = myFunction`.
-     
+And for HTML elements the syntax is shared:
+
+```hbs
+<div class="important">
+```
+
+Fragments, Glimmer components that do not have a topmost element, cannot automatically reflect HTML attributes. It is not an error to pass attributes to a fragment, they just have no default behavior. For more details about how a component author can decide which element receives attributes, see "Template Definition Syntax".
+
+In HTML, every attribute value is necessarily either a string or completely absent. For these values, Ember templates will match HTML semantics (for example `checked=""` sets an attribute `checked` with the value `""`). However in Ember templates, we can dynamically bind arbitrary value types to an attribute. For non-string types (booleans, numbers, functions) the framework must define semantics for those types.
+
+* **boolean values**: These values express the addition or removal of the attribute. So given `isReady = true`, then
+  ```hbs
+  <my-checkbox checked={{isReady}} />
+  ```
+  will result in the HTML attribute `checked` being added, not `checked="true"`. When the value is `false`, the `checked` attribute will be absent or removed.
+* **function values**: These values result in a property set on the HTML Element. So:
+  ```hbs
+  <some-component onclick={{myFunction}}
+  ```
+  Sets a property `element.onclick = myFunction`. Because DOM properties cannot
+  be represented in HTML, functions set this way have no effect when using
+  Fastboot.
+
 TODO: I want the above attribute value semantics to be the same for glimmer components vs plain elements. But we are constrained in the semantics we can change on plain elements, since they are existing API. Are there inconsistencies between my proposal and the existing plain-element semantics?
 
 Note that the use of quotation marks necessarily casts a value to string, so
 
-    <some-component checked="{{isTrue}}" />
-    
-would result in `checked="true"` despite `isTrue` having a boolean value. This is not new, it's the existing semantics of string concatenation in Ember Handlebars.
+```hbs
+<some-component checked="{{isTrue}}" />
+```
+
+would result in `checked="true"` despite `isTrue` having a boolean value. This is not new, it's the existing semantics of string concatenation in Ember templates.
 
 TODO: we should discuss attribute name normalization. It should match the HTML spec. I think Kris had insights on this.
 
 ### Arguments
 
-You can pass arguments to Glimmer components using the `@` syntax:
+You can pass arguments, data for rendering, to Glimmer components using the `@` syntax:
 
-    <power-select @options={{availablePeople}} @selected={{currentPerson}} />
-    
+```hbs
+<power-select @options={{availablePeople}} @selected={{currentPerson}} />
+```
+
 Attributes and arguments are not the same thing. Traditional Ember components blur this distinction -- they really only have arguments, but by convention often treat some of those arguments as attributes too. Glimmer components make the distinction crisp.
 
-The semantics of arguments are defined by the component author. They don't have any HTML meaning, it's up to the component to use them for something.
+The semantics of arguments are defined by the component author. They don't have any HTML reflection. It is up to the component author to use them for something.
 
-Argument binding is one-way. If the value in the caller changes, the callee will receive the changed value. If the value in the callee changes, the caller will not see the changed value.
+Argument binding is one-way. If the value in the caller changes, the callee will receive the changed value. The callee has no mechanism to set the value for the caller.
 
 TODO: do we still want opt-in two-way binding, ala `mut`? What is our solution for the case where a child component truly has higher-fidelity state than its parent? How do we avoid echoes despite arbitrary asynchrony?
 
@@ -127,22 +134,23 @@ TODO: do we still want opt-in two-way binding, ala `mut`? What is our solution f
 
 Glimmer components accept blocks and yield block parameters, just like traditional Ember components:
 
-    <power-select as |choice|>
-      {{choice}}
-    {{else}}
-      No choices available.
-    </power-select>
+```hbs
+<power-select as |choice|>
+  {{choice}}
+{{else}}
+  No choices available.
+</power-select>
+```
 
 TODO: this else-block syntax is a strawman -- what should it really be? `<else>` could become a future HTML tag. `{{else}}` seems weird because it doesn't match the surrounding style. `<power-select-else>` seems terribly verbose.
 
 ### Interoperability
 
-Glimmer components can invoke traditional components. Traditional components can invoke Glimmer components.
+Glimmer components can invoke traditional Ember components. Traditional Ember components can invoke Glimmer components.
 
 Glimmer components can still be invoked using curly syntax! This is important for easy compatibility, and it may be desirable for some kinds of components to always be used via curlies (particularly components that are providing control flow behaviors like `liquid-if` or custom forms of `#each`).
 
 When invoked in curly syntax, you get only arguments, not attributes (since we can't distinguish the two). Your bindings are still one-way. TODO: am I missing any edge cases here? Is there a reason to make component authors explicitly declare which invocation syntax they support?
-
 
 ## Template Definition Syntax
 
@@ -150,100 +158,204 @@ Just like traditional Ember components, Glimmer components may have a template, 
 
 Unlike traditional Ember components, Glimmer components have no implicit top-level element. What you see in the template is what you get. Given a `my-message` component with this template:
 
-    <span style="color:red">
-      {{yield}}
-    </span>
+```hbs
+<span style="color:red">
+  {{yield}}
+</span>
+```
 
 If you call it this like:
 
-    <my-message class="important" >
-      Hello world
-    </my-message>
+```hbs
+<my-message class="important" >
+  Hello world
+</my-message>
+```
 
-    
 It will result in DOM like this:
 
-    <span style="color:red" class="important">
-      Hello world
-    </span>
+```hbs
+<span style="color:red" class="important">
+  Hello world
+</span>
+```
+
+### Fragments
+
+Components with zero elements (a template with out text or value rendeing) or
+multiple root elements are called "fragments". Fragments disregard attributes
+since the root elements is missing or ambiguous.
+
+To allow passed attributes to attach to the DOM, a frament can use the
+`@@attibutes` syntax to choose which element will reflect them. This syntax
+means "pass all the attributes I was given onto this element". For example this
+invocation:
+
+```hbs
+<some-component data-name="nicki">
+```
+
+And this definition template:
+
+```hbs
+<h1>Name</h1>
+<div @@attributes>Coming soon!</div>
+```
+
+Would render the following HTML:
+
+```html
+<h1>Name</h1>
+<div data-name="nicki">Coming soon!</div>
+```
+
+### Components and web components as root elements
+
+In some cases the root element of a template may itself be another component or
+web component. This is valid. For example this invocation:
+
+```hbs
+<article-wrapper class="spotlight">
+  {{body}}
+</article-wrapper>
+```
+
+And this definition template:
+
+```hbs
+<article-body>
+  {{yield}}
+</article-body>
+```
+
+Where `article-body` is either another Ember component or a web component. In
+this case `@@attributes` is again useful for passing the attributes of an
+invocation down. For example, again our invocation template:
+
+```hbs
+<article-wrapper class="spotlight">
+  My article body
+</article-wrapper>
+```
+
+And this definition template for `article-wrapper`:
+
+```hbs
+<article-body @@attributes>
+  {{yield}}
+</article-body>
+```
+
+And this definition template for `article-body`:
+
+```hbs
+<div>{{yield}}</div>
+```
+
+Would result in this HTML:
+
+```html
+<div class="spotlight">
+  My article body
+</div>
+```
+
+Note that `@@attributes` only passes down HTML attributes. Arguments are cannot
+be passed down in a batch, and instead each `@arg=` must be passed down
+explicitly.
 
 ### Attribute Merging
 
 Since both the caller of a component and the author of a component may choose to set the same HTML attributes, we define the following attribute merging rules.
 
   1. `class` is concatenated with a space separator, so that both caller and author may independently control their own list of class names and there is no conflict. Any name that appears in either place will appear on the final HTML element.
-
   2. `style` values are merged on a property-by-property basis, with the caller taking precedence over the author.
-
   3. For any other attribute, the caller's value takes priority.
 
 Here's an example that demonstrates all three rules:
 
-    <div style="width:100%; color:red" aria-role="dialog" class="message-box"></div>
-    
-And the invocation
+```hbs
+<div style="width:100%; color:red" aria-role="dialog" class="message-box"></div>
+```
 
-    <the-component style="color:blue" aria-role="alert" class="warning" />
-    
-The resulting HTML would be
+And the invocation:
 
-    <div style="width:100%; color:blue" aria-role="alert" class="message-box warning"></div>
+```hbs
+<the-component style="color:blue" aria-role="alert" class="warning" />
+```
+
+The resulting HTML would be:
+
+```hbs
+<div style="width:100%; color:blue" aria-role="alert" class="message-box warning"></div>
+```
 
 TODO: we need a more complete definition of the style merging rule that cover the whole spec for what is legal within `style` attributes. See https://www.w3.org/TR/css-syntax-3/, in particular the [parse a list of declarations](https://www.w3.org/TR/css-syntax-3/#parse-a-list-of-declarations0) parser entry point, which is the one relevant to HTML style attributes. Thankfully this only pulls in a subset of the entire CSS syntax.
 
 ### Recursive Invocation
 
-It should be possible to define a component with a custom element name. For example, if you want your `display-folder` component to actually result in the DOM custom element `<display-folder>`, you can say so within the component definition:
+It is possible to define a glimmer component with an HTML custom element for a root element. For example, if you want your `display-folder` component to actually result in the DOM custom element `<display-folder>`, you can say so within the component definition:
 
-    <display-folder>
-      {{yield}}
-    </display-folder>
-    
+```hbs
+<display-folder>
+  {{yield}}
+</display-folder>
+```
+
 However, it should also be possible for a component to recursively invoke itself. This would appear to conflict with the above example (we don't want display-folder to infinitely recurse -- within its own definition, `display-folder` is actually an HTML element name, not a component invocation).
 
-Therefore, we make a rule that *the top-level element in a component's template is never treated as a component invocation.*
+Therefore, we make a rule that *the top-level element in a component's template is never treated as an invocation of that template itself.*
 
 This allows both use cases to coexist: the top-level element defines the component's HTML tag, while any inner uses of its own name are recursive invocations:
 
-    <display-folder>
-     {{#each @folder.children as |child|}}
-       {{#if child.isFolder}}
-         <display-folder @folder={{child}} />
-       {{else}}
-         <div>{{child.name}}</div>
-       {{/if}}
-     {{/each}}
-    </display-folder>
+```hbs
+<display-folder>
+ {{#each @folder.children as |child|}}
+   {{#if child.isFolder}}
+     <display-folder @folder={{child}} />
+   {{else}}
+     <div>{{child.name}}</div>
+   {{/if}}
+ {{/each}}
+</display-folder>
+```
 
-TODO: should we support dynamic tagname? Like
+TODO: should we support a dynamic tag name? Like
 
-    <{{tagName}}>
-    </{{tagName}}>
+```hbs
+<{{tagName}}>
+</{{tagName}}>
+```
 
 ### Fragments
 
 Fragment components are declared by using the special top-level element `<fragment>`
 
-    <fragment>
-      I am a fragment
-    </fragment>
-    
+```hbs
+<fragment>
+  I am a fragment
+</fragment>
+```
+
 This is special because `<fragment>` is *not* output to the DOM. It is elided. Invoking the above component results in only an HTML text node, no elements at all.
 
 An attractive alternative would be to allow fragments to have no element at all
 
-    I am a fragment
-    
+```hbs
+I am a fragment
+```
+
 Or many top-level elements
 
-    <div></div>
-    <div></div>
+```hbs
+<div></div>
+<div></div>
+```
 
 And thus implicitly allow any component to become a fragment if it doesn't satisfy the "one top-level element" rule. However, this would have significant downsides:
 
- - the addition of an extra element at the end of a template suddenly changes the whole meaning of your component from "normal component" to "fragment component". Since their semantics differ in important ways, this will cause surprising breakage, like missing HTML attributes. TODO: the attribute ambiguity problem could go away if we make it an error to pass attributes to a fragment unless the fragment explicitly uses `@@attributes`.
- 
- - fragments need to allow component invocation as their first element. If that first element is not contained within a `<fragment>` marker, it creates a treacherous difference from the rule defined in the Recursive Invocation section ("the top-level element in a component's template is never treated as a component invocation"). TODO: we could address this concern by replacing that rule with a different syntax that prevents invocation.
+* the addition of an extra element at the end of a template suddenly changes the whole meaning of your component from "normal component" to "fragment component". Since their semantics differ in important ways, this will cause surprising breakage, like missing HTML attributes. TODO: the attribute ambiguity problem could go away if we make it an error to pass attributes to a fragment unless the fragment explicitly uses `@@attributes`.
+* fragments need to allow component invocation as their first element. If that first element is not contained within a `<fragment>` marker, it creates a treacherous difference from the rule defined in the Recursive Invocation section ("the top-level element in a component's template is never treated as a component invocation"). TODO: we could address this concern by replacing that rule with a different syntax that prevents invocation.
 
 TODO: if we can statically address the downsides of implicit fragments, it would be really nice to not require `<fragment>`, especially to support people who are just breaking up existing piles of HTML into templates.
 
@@ -251,10 +363,12 @@ TODO: if we can statically address the downsides of implicit fragments, it would
 
 Within a component's template, its arguments are accessible via `@` syntax:
 
-    <div>
-      {{@message}}
-    </div>
-    
+```hbs
+<div>
+  {{@message}}
+</div>
+```
+
 This is intended to support the mental connection between invocation and definition. And it makes it clear to the reader (and the Glimmer runtime, for optimization purposes) which values came from outside the component.
 
 ## Javascript Syntax
@@ -271,24 +385,18 @@ That said, we should strive for consistent coding style throughout community doc
 
 TODO. Constraints:
 
- - for future compatibility, components need to at least be unambiguously tagged as components. So exporting a plain function or arbitrary class would not be sufficient.
- 
- - we could require only a class decorator
- 
- - or we could have a base class
- 
- - must ensure that the implementation can avoid de-opts when hooks are only sometimes present.
- 
- - pretty clear that base will not be current Ember.Object. It will be a subset that we want to work within pure Glimmer.
+* For future compatibility, components need to at least be unambiguously tagged as components. So exporting a plain function or arbitrary class would not be sufficient.
+* We could require only a class decorator
+* Or we could have a base class
+* Must ensure that the implementation can avoid de-opts when hooks are only sometimes present.
+* Pretty clear that base will not be current Ember.Object. It will be a subset that we want to work within pure Glimmer.
 
 ### Lifecycle Hooks
 
 TODO. Document the lifecycle hooks and rationalize their names.
 
- - "attrs" in hook names should become "args" (didReceiveAttrs -> didReceiveArgs)
- 
- - didInsertElement/willDestroyElement are now weird names relative to the more modern hook naming pattern. Plus fragments don't have an element, and it would be nice to have hooks that make sense in that case too.
- 
+* "attrs" in hook names should become "args" (`didReceiveAttrs` -> `didReceiveArgs`)
+* `didInsertElement`/`willDestroyElement` are now weird names relative to the more modern hook naming pattern. Plus fragments don't have an element, and it would be nice to have hooks that make sense in that case too.
 
 ### Arguments
 
@@ -300,7 +408,7 @@ TODO: if dependent keys are still a thing, should we allow both `args.foo` and `
 
 Attributes that were passed into the component by its caller are available as read-only properties on `this.attributes`. This has a reasonable symmetry with the `@@attributes` template syntax.
 
-Attributes set on the top-level element within a component's own template are not included in `this.attributes`. It is analogous to `this.args` -- it exists to tell you what your caller was asking for. 
+Attributes set on the top-level element within a component's own template are not included in `this.attributes`. It is analogous to `this.args` -- it exists to tell you what your caller was asking for.
 
 ### Blocks
 
@@ -308,7 +416,7 @@ TODO: `hasBlock`?
 
 ### DOM access
 
-`this.element` is your HTML element. 
+`this.element` is your HTML element.
 
 Accessing `this.element` from within a fragment should throw a helpful error.
 
@@ -324,7 +432,7 @@ How much of current `computed` do we want to bake into Glimmer? Can we do more a
 
 Plain getters are ideal from a developer ergonomics standpoint. But without some smart dependency tracking, they spread contagious volatility throughout the component hierarchy.
 
-It would not be unreasonable to adopt a rule like Vue, which says that all automatically tracked properties need to be present at initialization (so that getters can be installed for them). 
+It would not be unreasonable to adopt a rule like Vue, which says that all automatically tracked properties need to be present at initialization (so that getters can be installed for them).
 
 Can we drop `this.get`? Likely yes.
 
@@ -332,7 +440,7 @@ Can we drop `set`? Probably not?
 
 ### Non-exhaustive list of things not in Glimmer components
 
-Observer support. 
+Observer support.
 
 Event support. (This may be debatable -- if we keep event support, lets make sure it's an explicitly designed API and not sneaking in any existing semantics)
 
@@ -368,7 +476,6 @@ at any level?
 
 How should this feature be introduced and taught to existing Ember
 users?
-
 
 # Drawbacks
 


### PR DESCRIPTION
* Copy cleanup.
* Use "Glimmer component" capitalization consistently
* Use code blocks with syntax
* Split the discussion of non-string attributes from `@@attributes`
* Move `@@attributes` to proposed fragments in template definition

I believe I may have screwed up your version of the `@@attributes` stuff and even changed the recursive invocation for a root element rule. We should discuss.